### PR TITLE
Allow the flock for kernel builds

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -100,6 +100,7 @@ var Configuration = map[string]PathConfig{
 	"nproc":    Allowed,
 	"openssl":  Allowed,
 	"patch":    Allowed,
+	"perl":     Log,
 	"pstree":   Allowed,
 	"python3":  Allowed,
 	"realpath": Allowed,

--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -85,6 +85,7 @@ var Configuration = map[string]PathConfig{
 	"expr":     Allowed,
 	"find":     Allowed,
 	"flex":     Allowed,
+	"flock":    Allowed,
 	"fuser":    Allowed,
 	"getopt":   Allowed,
 	"git":      Allowed,


### PR DESCRIPTION
`flock` is an process locks manager for shell scripts.
It commonly used by WireGuard module importer at kernel's Kbuild.
If we didn't allow it from soong side, soong will fails to compile the kernel that have WireGuard on it.


