### PR TITLE
soong: Forbid arm-linux-androidkernel-as and arm-linux-androidkernel-ld

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -120,17 +120,19 @@ var Configuration = map[string]PathConfig{
 
 	// Host toolchain is removed. In-tree toolchain should be used instead.
 	// GCC also can't find cc1 with this implementation.
-	"ar":         Forbidden,
-	"as":         Forbidden,
-	"cc":         Forbidden,
-	"clang":      Forbidden,
-	"clang++":    Forbidden,
-	"gcc":        Forbidden,
-	"g++":        Forbidden,
-	"ld":         Forbidden,
-	"ld.bfd":     Forbidden,
-	"ld.gold":    Forbidden,
-	"pkg-config": Forbidden,
+	"ar":                          Forbidden,
+	"arm-linux-androidkernel-as":  Forbidden,
+	"arm-linux-androidkernel-ld":  Forbidden,
+	"as":                          Forbidden,
+	"cc":                          Forbidden,
+	"clang":                       Forbidden,
+	"clang++":                     Forbidden,
+	"gcc":                         Forbidden,
+	"g++":                         Forbidden,
+	"ld":                          Forbidden,
+	"ld.bfd":                      Forbidden,
+	"ld.gold":                     Forbidden,
+	"pkg-config":                  Forbidden,
 
 	// On Linux we'll use the toybox versions of these instead.
 	"basename":  LinuxOnlyPrebuilt,


### PR DESCRIPTION
* Pops up on msm8998 kernel with clang 11.0.4

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>
Change-Id: I6a17b731283822374852ec77cf9d5293bd924a70